### PR TITLE
refactor: native module changed with a more versatile one

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CSS from 'Footer.css';
+import CSS from './Footer.css';
 
 export default function Footer() {
   return <div className={CSS.footerWrapper}>Hello</div>;

--- a/app/components/ProcessList.css
+++ b/app/components/ProcessList.css
@@ -30,6 +30,9 @@
   align-items: center;
   height: inherit;
   width: 50%;
+  border-radius: 0.2em;
+  background: #e2e3e5;
+  margin-left: -1em;
 }
 
 .processSpanElement {
@@ -45,7 +48,7 @@
 }
 
 .processColorIndicator {
-  width: 3em;
+  width: 2em;
   height: inherit;
   background: red;
   border-top-left-radius: 0.2em;

--- a/app/components/ProcessList.css
+++ b/app/components/ProcessList.css
@@ -44,6 +44,14 @@
   font-weight: 700;
 }
 
+.processColorIndicator {
+  width: 3em;
+  height: inherit;
+  background: red;
+  border-top-left-radius: 0.2em;
+  border-bottom-left-radius: 0.2em;
+}
+
 .usagePercentageIndicator {
   height: 0.5em;
   background-color: yellow;

--- a/app/components/ProcessList.tsx
+++ b/app/components/ProcessList.tsx
@@ -48,12 +48,6 @@ export default function ProcessList() {
                 </span>
               </div>
             </div>
-            {/* <div
-              className={CSS.usagePercentageIndicator}
-              style={{
-                width: `${((process.usageTime / screenTime) * 100).toFixed(1)}%`,
-              }}
-            ></div> */}
           </div>
         );
       })}

--- a/app/components/ProcessList.tsx
+++ b/app/components/ProcessList.tsx
@@ -2,41 +2,12 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { RiZzzLine } from 'react-icons/ri';
 import { VscVmRunning } from 'react-icons/vsc';
+import StringToColor from 'string-to-color';
 import {
   allProcesses,
   totalScreenTime,
 } from '../features/observer/observerSlice';
 import CSS from './ProcessList.css';
-
-// const normalizeProcessName = (rawName: string) => {
-//   // Process might be Chrome, VS Code as xxxx - xxxx - Google Chrome
-//   if (rawName.includes(' - ')) {
-//     const splittedName = rawName.split(' - ');
-//     if (splittedName[0] === 'Developer Tools') {
-//       return splittedName[0];
-//     }
-//     return splittedName[splittedName.length - 1];
-//   }
-//   return rawName;
-// };
-
-const colorPalette = [
-  '#005CE6',
-  '#4791FF',
-  '#40A077',
-  '#50B988',
-  '#91D4BC',
-  '#F3FFC6',
-  '#C3EB78',
-  '#B6174B',
-  '#CD7E7C',
-  '#E0AFA0',
-  '#FFAC81',
-  '#FF928B',
-  '#FEC3A6',
-  '#EFE9AE',
-  '#CDEAC0',
-];
 
 export default function ProcessList() {
   const processLog = useSelector(allProcesses);
@@ -44,13 +15,13 @@ export default function ProcessList() {
 
   return (
     <div className={CSS.processListWrapper}>
-      {processLog.map((process, index) => {
+      {processLog.map((process) => {
         return (
           <div className={CSS.processCard} key={process.id}>
             <div className={CSS.processCardBody}>
               <div
                 className={CSS.processColorIndicator}
-                style={{ background: colorPalette[index] }}
+                style={{ background: StringToColor(process.owner.name) }}
               />
               <div className={CSS.processCardBodyColumn}>
                 <span className={CSS.processName}>{process.owner.name}</span>

--- a/app/components/ProcessList.tsx
+++ b/app/components/ProcessList.tsx
@@ -20,22 +20,40 @@ import CSS from './ProcessList.css';
 //   return rawName;
 // };
 
+const colorPalette = [
+  '#005CE6',
+  '#4791FF',
+  '#40A077',
+  '#50B988',
+  '#91D4BC',
+  '#F3FFC6',
+  '#C3EB78',
+  '#B6174B',
+  '#CD7E7C',
+  '#E0AFA0',
+  '#FFAC81',
+  '#FF928B',
+  '#FEC3A6',
+  '#EFE9AE',
+  '#CDEAC0',
+];
+
 export default function ProcessList() {
   const processLog = useSelector(allProcesses);
   const screenTime = useSelector(totalScreenTime);
 
   return (
     <div className={CSS.processListWrapper}>
-      {processLog.map((process) => {
+      {processLog.map((process, index) => {
         return (
-          <div className={CSS.processCard} key={process.windowPid}>
+          <div className={CSS.processCard} key={process.id}>
             <div className={CSS.processCardBody}>
+              <div
+                className={CSS.processColorIndicator}
+                style={{ background: colorPalette[index] }}
+              />
               <div className={CSS.processCardBodyColumn}>
-                <span className={CSS.processName}>
-                  {process.windowName.length > 20
-                    ? process.windowClass
-                    : process.windowName}
-                </span>
+                <span className={CSS.processName}>{process.owner.name}</span>
                 <span>
                   {`Active Usage: ${(
                     (process.usageTime / screenTime) *

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -11,13 +11,13 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import { app, BrowserWindow, ipcMain, Menu } from 'electron';
+import activeWin from 'active-win';
 // import { autoUpdater } from 'electron-updater';
 // import log from 'electron-log';
 import * as Sentry from '@sentry/electron';
 // import MenuBuilder from './menu';
-import { ProcessType } from './utils/typeKeeper';
 
-const activeWindows = require('electron-active-window');
+const desktopIdle = require('desktop-idle');
 
 Sentry.init({
   dsn:
@@ -102,10 +102,12 @@ const createWindow = async () => {
       return;
     }
     const intervalID = setInterval(() => {
-      activeWindows()
-        .getActiveWindow()
-        .then((result: ProcessType) =>
-          mainWindow?.webContents.send('activeProcess', result)
+      activeWin()
+        .then((result) =>
+          mainWindow?.webContents.send('activeProcess', {
+            ...result,
+            idleTime: desktopIdle.getIdleTime(),
+          })
         )
         .catch(() => {
           console.log('Could not retrieve current window data');

--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "electron-active-window": "^0.0.4"
+    "active-win": "^6.2.0",
+    "desktop-idle": "^1.3.0"
   }
 }

--- a/app/utils/electronStore.ts
+++ b/app/utils/electronStore.ts
@@ -14,11 +14,7 @@ export default function GetStoreInstance() {
   return config.store;
 }
 
-export const AddNewProcessToStorage = (
-  key: string,
-  payload: ProcessType,
-  hasBeenIdle: boolean
-) => {
+export const AddNewProcessToStorage = (key: string, payload: ProcessType) => {
   const oldSession = config.store?.get('dailySessions')[key];
   if (!oldSession) {
     config.store?.set(`dailySessions.${key}`, {
@@ -26,9 +22,6 @@ export const AddNewProcessToStorage = (
       screenTime: 0,
     });
   } else {
-    if (hasBeenIdle) {
-      oldSession.screenTime += +payload.idleTime;
-    }
     oldSession.processes.push(payload);
     config.store?.set(`dailySessions.${key}`, oldSession);
   }

--- a/app/utils/typeKeeper.ts
+++ b/app/utils/typeKeeper.ts
@@ -1,11 +1,20 @@
-export interface ProcessType {
-  windowPid: number;
-  windowName: string;
-  windowClass: string;
-  os: 'windows' | 'macos' | 'linux';
-  idleTime: number;
+import { Result as ActiveWinResultType } from 'active-win';
+
+type UsageMetricsType = {
   usageTime: number;
-}
+  idleTime: number;
+};
+
+export type ProcessType = ActiveWinResultType & UsageMetricsType;
+
+// export interface ProcessType {
+//   windowPid: number;
+//   windowName: string;
+//   windowClass: string;
+//   os: 'windows' | 'macos' | 'linux';
+//   idleTime: number;
+//   usageTime: number;
+// }
 
 export interface SettingsType {
   isDrawerOpen?: boolean;

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2,17 +2,126 @@
 # yarn lockfile v1
 
 
-electron-active-window@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/electron-active-window/-/electron-active-window-0.0.4.tgz#ea9c1d97bdab46fd7faca971eeabc7a0906ff16a"
+active-win@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/active-win/-/active-win-6.2.0.tgz#306af0589e91a171bbcc43efc07802b1aa485830"
+  optionalDependencies:
+    ffi-napi "^2.4.5"
+    ref-napi "^3.0.0"
+    ref-struct-napi "^1.1.0"
+    ref-wchar-napi "^1.0.2"
+
+debug@2:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
-    fs "^0.0.1-security"
-    node-addon-api "^1.7.1"
+    ms "2.0.0"
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+debug@^3.1.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
+  dependencies:
+    ms "^2.1.1"
 
-node-addon-api@^1.7.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+debug@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  dependencies:
+    ms "2.1.2"
+
+desktop-idle@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/desktop-idle/-/desktop-idle-1.3.0.tgz#7198b3f1bf147baac2217924bf647600c88d18be"
+
+ffi-napi@^2.4.5:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/ffi-napi/-/ffi-napi-2.5.0.tgz#77802081e4f3c2160d536781e84e00f8a88961f3"
+  dependencies:
+    debug "^3.1.0"
+    get-uv-event-loop-napi-h "^1.0.5"
+    node-addon-api "1.6.1"
+    node-gyp-build "^4.2.1"
+    ref-napi "^1.5.2"
+    ref-struct-di "^1.1.0"
+
+get-symbol-from-current-process-h@^1.0.1, get-symbol-from-current-process-h@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/get-symbol-from-current-process-h/-/get-symbol-from-current-process-h-1.0.2.tgz#510af52eaef873f7028854c3377f47f7bb200265"
+
+get-uv-event-loop-napi-h@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/get-uv-event-loop-napi-h/-/get-uv-event-loop-napi-h-1.0.6.tgz#42b0b06b74c3ed21fbac8e7c72845fdb7a200208"
+  dependencies:
+    get-symbol-from-current-process-h "^1.0.1"
+
+iconv@2:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/iconv/-/iconv-2.3.5.tgz#5f9b9612f5b15313286748d030c6ff29efdefa33"
+  dependencies:
+    nan "^2.14.0"
+    safer-buffer "^2.1.2"
+
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+ms@2.1.2, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+
+nan@^2.14.0:
+  version "2.14.1"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
+
+node-addon-api@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.6.1.tgz#a9881c8dbc6400bac6ddedcb96eccf8051678536"
+
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+
+node-gyp-build@^4.2.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+
+ref-napi@^1.4.2, ref-napi@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/ref-napi/-/ref-napi-1.5.2.tgz#a29f9a0c1aff02f01e023199e4aa8fe7f11f25b9"
+  dependencies:
+    debug "^3.1.0"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.1"
+
+ref-napi@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ref-napi/-/ref-napi-3.0.1.tgz#442c0b266c14620a3c3b5a1d9c8d8d997f33a86d"
+  dependencies:
+    debug "^4.1.1"
+    get-symbol-from-current-process-h "^1.0.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.1"
+
+ref-struct-di@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ref-struct-di/-/ref-struct-di-1.1.1.tgz#5827b1d3b32372058f177547093db1fe1602dc10"
+  dependencies:
+    debug "^3.1.0"
+
+ref-struct-napi@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ref-struct-napi/-/ref-struct-napi-1.1.1.tgz#272a870a0ccb8244bd06ac851ffafbfc33dcd951"
+  dependencies:
+    debug "2"
+    ref-napi "^1.4.2"
+
+ref-wchar-napi@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ref-wchar-napi/-/ref-wchar-napi-1.0.2.tgz#0028da106953fdf48b2eb944d33f9d1747a6f2a9"
+  dependencies:
+    iconv "2"
+    ref-napi "^1.4.2"
+
+safer-buffer@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"

--- a/package.json
+++ b/package.json
@@ -255,7 +255,8 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.5",
-    "source-map-support": "^0.5.19"
+    "source-map-support": "^0.5.19",
+    "string-to-color": "^2.2.2"
   },
   "devEngines": {
     "node": ">=7.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3953,6 +3953,10 @@ colorette@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.1.tgz#4d0b921325c14faf92633086a536db6e89564b1b"
 
+colornames@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/colornames/-/colornames-1.1.1.tgz#f8889030685c7c4ff9e2a559f5077eb76a816f96"
+
 colors@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
@@ -4903,7 +4907,7 @@ ejs@^3.1.3:
   dependencies:
     jake "^10.6.1"
 
-electron-builder@^22.8.1:
+electron-builder@^22.3.6:
   version "22.8.1"
   resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-22.8.1.tgz#84295190dae17b3892df7aa39ac334983aeaea06"
   dependencies:
@@ -6414,6 +6418,10 @@ hash.js@^1.0.0, hash.js@^1.0.3:
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
+
+hex-rgb@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/hex-rgb/-/hex-rgb-4.2.0.tgz#fb377f2e5658fc924f1efa189685922e56ecaf0f"
 
 highlight-es@^1.0.0:
   version "1.0.3"
@@ -7976,13 +7984,25 @@ lodash.memoize@4.1.2, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.padend@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
+
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
+lodash.trimstart@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz#8ff4dec532d82486af59573c39445914e944a7f1"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+
+lodash.words@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.words/-/lodash.words-4.2.0.tgz#5ecfeaf8ecf8acaa8e0c8386295f1993c9cf4036"
 
 "lodash@4.6.1 || ^4.16.1", lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
@@ -10402,6 +10422,10 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
 
+rgb-hex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rgb-hex/-/rgb-hex-3.0.0.tgz#eab0168cc1279563b18a14605315389142e2e487"
+
 rgb-regex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
@@ -11057,6 +11081,17 @@ string-length@^4.0.1:
   dependencies:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
+
+string-to-color@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/string-to-color/-/string-to-color-2.2.2.tgz#46210bf7777dc9198dcdf997bd18ae6749cc9a73"
+  dependencies:
+    colornames "^1.1.1"
+    hex-rgb "^4.1.0"
+    lodash.padend "^4.6.1"
+    lodash.trimstart "^4.5.1"
+    lodash.words "^4.2.0"
+    rgb-hex "^3.0.0"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
### Changes
 - `electron-active-window` removed from `app/package.json`
 - `active-win` added to trace processes
 - `desktop-idle` added to track idleness of processes

### Additions
 - ~~A static color palette added to assign processes - not flexible enough to handle dynamic data~~ 
 - `string-to-color` module added to generate dynamic color for each process with their name