### PR TITLE
feat: sending application to tray & pomodoro technique notifications implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Features 🎨
 
 - **Process Tracking**: Retrieve process information and details about their idle / usage time
-- **Alarms (WIP):** Define a upper boundary for your screen time and get notified if reached
+- **Pomodoro Alarms:** Enable to get notifications about when to stop/start to work
 - **Settings (WIP):** Defines settings related to processes, run on start-up etc.
 - **Persistent Data:** Session information persist on your hard-drive
   - File Location:

--- a/app/components/Footer.css
+++ b/app/components/Footer.css
@@ -1,0 +1,37 @@
+.footerWrapper {
+  height: 3em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 0.5em;
+  border-top: 2px solid #3c3c3c;
+}
+
+.footerMainColumn {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.pomodoroCountdown {
+  font-size: 23px;
+}
+
+.pomodoroIterationType {
+  font-size: 14px;
+}
+
+.breakInfoColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 15px;
+}
+
+.workInfoColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 15px;
+}

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { getCurrentIteration } from '../features/observer/observerSlice';
+import CSS from './Footer.css';
+
+export default function Footer(): JSX.Element {
+  const currentPomodoroIteration = useSelector(getCurrentIteration);
+  const isWorkIteration = currentPomodoroIteration.type === 'work';
+  return (
+    <div className={CSS.footerWrapper}>
+      <div className={CSS.workInfoColumn}>
+        Work
+        <span>{currentPomodoroIteration.workIteration}</span>
+      </div>
+      <div className={CSS.footerMainColumn}>
+        <span className={CSS.pomodoroIterationType}>
+          {isWorkIteration ? `Break Time in` : `Start Working in`}
+        </span>
+        <span className={CSS.pomodoroCountdown}>
+          {new Date(
+            (currentPomodoroIteration.limit -
+              (currentPomodoroIteration.totalTime %
+                currentPomodoroIteration.limit)) *
+              1000
+          )
+            .toISOString()
+            .substr(14, 5)}
+        </span>
+      </div>
+      <div className={CSS.breakInfoColumn}>
+        Break
+        <span>{currentPomodoroIteration.breakIteration}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -8,6 +8,7 @@ import { ProcessType } from '../utils/typeKeeper';
 import ProcessList from './ProcessList';
 import SummaryHeader, { StartObserver, StopObserver } from './SummaryHeader';
 import SettingsDrawer from './SettingsDrawer';
+import Footer from './Footer';
 import CSS from './Home.css';
 
 export default function Home(): JSX.Element {
@@ -38,12 +39,15 @@ export default function Home(): JSX.Element {
 
   const renderSettingsDrawer = useMemo(() => <SettingsDrawer />, []);
 
+  const renderFooter = useMemo(() => <Footer />, []);
+
   return (
     <div className={CSS.container}>
       {renderSummaryHeader}
       {/* <Link to={routes.COUNTER}>to Counter</Link> */}
       {renderSettingsDrawer}
       {renderProcessList}
+      {renderFooter}
     </div>
   );
 }

--- a/app/components/ProcessList.css
+++ b/app/components/ProcessList.css
@@ -5,6 +5,7 @@
   overflow-y: auto;
   height: calc(100vh - 7em);
   padding-top: 0.5em;
+  transition: all 0.2s ease-in;
 }
 
 .processCard {

--- a/app/components/ProcessList.tsx
+++ b/app/components/ProcessList.tsx
@@ -7,14 +7,19 @@ import {
   allProcesses,
   totalScreenTime,
 } from '../features/observer/observerSlice';
+import { isPomodoroEnabled } from '../features/settings/settingsSlice';
 import CSS from './ProcessList.css';
 
 export default function ProcessList() {
   const processLog = useSelector(allProcesses);
   const screenTime = useSelector(totalScreenTime);
+  const pomodoroEnabled = useSelector(isPomodoroEnabled);
 
   return (
-    <div className={CSS.processListWrapper}>
+    <div
+      className={CSS.processListWrapper}
+      style={pomodoroEnabled ? { height: 'calc(100vh - 11em)' } : {}}
+    >
       {processLog.map((process) => {
         return (
           <div className={CSS.processCard} key={process.id}>

--- a/app/components/SettingsDrawer.tsx
+++ b/app/components/SettingsDrawer.tsx
@@ -6,15 +6,18 @@ import {
   ToggleDrawerVisibility,
   startApplicationAtBoot,
   shouldAppLaunchAtBoot,
+  enablePomodoroTracker,
+  isPomodoroEnabled,
 } from '../features/settings/settingsSlice';
 import CSS from './SettingsDrawer.css';
 
-type SettingKinds = 'LaunchSetting' | 'AlarmSetting';
+type SettingKinds = 'LaunchSetting' | 'PomodoroSetting';
 
 export default function SettingsDrawer() {
   const dispatch = useDispatch();
   const isOpen = useSelector(isDrawerOpen);
   const launchAtBoot = useSelector(shouldAppLaunchAtBoot);
+  const pomodoroEnabled = useSelector(isPomodoroEnabled);
 
   const handleSettingsPanelVisibilityViaClick = useCallback(() => {
     dispatch(ToggleDrawerVisibility());
@@ -29,8 +32,8 @@ export default function SettingsDrawer() {
   const handleLaunchStartupPreference = useCallback(
     (target: SettingKinds) => (event: React.ChangeEvent<HTMLInputElement>) => {
       switch (target) {
-        case 'AlarmSetting':
-          // console.log(event.target.checked);
+        case 'PomodoroSetting':
+          dispatch(enablePomodoroTracker(event.target.checked));
           break;
         case 'LaunchSetting':
           dispatch(startApplicationAtBoot(event.target.checked));
@@ -80,13 +83,14 @@ export default function SettingsDrawer() {
           className={`${CSS.settingsMenuItem} ${CSS.disableMenuItemSeperator}`}
         >
           <div className={CSS.settingsMenuContent}>
-            <span>Enable screen-time limit</span>
+            <span>Enable pomodoro tracker</span>
             <input
               type="checkbox"
               id="screenTimeLimit"
-              onChange={handleLaunchStartupPreference('AlarmSetting')}
+              onChange={handleLaunchStartupPreference('PomodoroSetting')}
+              defaultChecked={pomodoroEnabled}
             />
-            <label htmlFor="screenTimeLimit">Screen Time Limit</label>
+            <label htmlFor="screenTimeLimit">Enable omodoro tracker</label>
           </div>
         </div>
       </div>

--- a/app/features/settings/settingsSlice.ts
+++ b/app/features/settings/settingsSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import DataStore, {
   UpdateApplicationBootPreferenceInStorage,
+  UpdatePomodoroStateInStorage,
 } from '../../utils/electronStore';
 import { SettingsType } from '../../utils/typeKeeper';
 // eslint-disable-next-line import/no-cycle
@@ -17,10 +18,7 @@ const prepareInitialState = (): SettingsType => {
     isDrawerOpen: false,
     preferences: {
       launchAtBoot: true,
-      alertInfo: {
-        enabled: false,
-        limit: 0,
-      },
+      isPomodoroEnabled: false,
     },
   };
 };
@@ -39,6 +37,10 @@ const SettingsSlice = createSlice({
       state.preferences.launchAtBoot = action.payload;
       UpdateApplicationBootPreferenceInStorage(action.payload);
     },
+    enablePomodoroTracker: (state, action: PayloadAction<boolean>) => {
+      state.preferences.isPomodoroEnabled = action.payload;
+      UpdatePomodoroStateInStorage(action.payload);
+    },
   },
 });
 
@@ -46,6 +48,7 @@ export const {
   closeSettingsDrawer,
   openSettingsDrawer,
   startApplicationAtBoot,
+  enablePomodoroTracker,
 } = SettingsSlice.actions;
 
 export const ToggleDrawerVisibility = (): AppThunk => {
@@ -65,3 +68,6 @@ export const isDrawerOpen = (state: RootState) => state.settings.isDrawerOpen;
 
 export const shouldAppLaunchAtBoot = (state: RootState) =>
   state.settings.preferences.launchAtBoot;
+
+export const isPomodoroEnabled = (state: RootState) =>
+  state.settings.preferences.isPomodoroEnabled;

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -18,6 +18,7 @@ import {
   Menu,
   powerMonitor,
   Tray,
+  Notification,
 } from 'electron';
 import activeWin from 'active-win';
 import AutoLaunch from 'auto-launch';
@@ -185,6 +186,14 @@ const createWindow = async () => {
       .catch((err) => {
         console.log('Could not launch controller state information', err);
       });
+  });
+
+  ipcMain.on('generateNotification', (_, title, body) => {
+    new Notification({
+      title,
+      body,
+      icon: getAssetPath('icon.png'),
+    }).show();
   });
 
   mainWindow.on('closed', () => {

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -10,10 +10,19 @@
  */
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
-import { app, BrowserWindow, ipcMain, Menu, powerMonitor } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  Event,
+  ipcMain,
+  Menu,
+  powerMonitor,
+  Tray,
+} from 'electron';
 import activeWin from 'active-win';
 import AutoLaunch from 'auto-launch';
 import * as Sentry from '@sentry/electron';
+import path from 'path';
 // import { autoUpdater } from 'electron-updater';
 // import log from 'electron-log';
 // import MenuBuilder from './menu';
@@ -101,6 +110,14 @@ const createWindow = async () => {
     await installExtensions();
   }
 
+  const RESOURCES_PATH = app.isPackaged
+    ? path.join(process.resourcesPath, 'resources')
+    : path.join(__dirname, '../resources');
+
+  const getAssetPath = (...paths: string[]): string => {
+    return path.join(RESOURCES_PATH, ...paths);
+  };
+
   mainWindow = new BrowserWindow({
     show: false,
     width: 500,
@@ -177,6 +194,44 @@ const createWindow = async () => {
 
   mainWindow.on('closed', () => {
     mainWindow = null;
+  });
+
+  let isQuiting = false;
+
+  const tray = new Tray(getAssetPath('icon.png'));
+
+  tray.on('double-click', () => {
+    mainWindow?.show();
+  });
+  tray.setToolTip('Chronos');
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Show',
+        click: () => {
+          mainWindow?.show();
+        },
+      },
+      {
+        label: 'Quit',
+        click: () => {
+          isQuiting = true;
+          app.quit();
+        },
+      },
+    ])
+  );
+
+  mainWindow.on('close', (e: Event) => {
+    if (!isQuiting) {
+      e.preventDefault();
+
+      mainWindow?.hide();
+    }
+  });
+
+  mainWindow.on('restore', () => {
+    mainWindow?.show();
   });
 
   // const menuBuilder = new MenuBuilder(mainWindow);

--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -140,12 +140,7 @@ const createWindow = async () => {
     if (!mainWindow) {
       throw new Error('"mainWindow" is not defined');
     }
-    if (process.env.START_MINIMIZED) {
-      mainWindow.minimize();
-    } else {
-      mainWindow.show();
-      mainWindow.focus();
-    }
+    mainWindow?.hide();
   });
 
   ipcMain.on('startObserving', initiateObserverTicker);

--- a/app/rootReducer.ts
+++ b/app/rootReducer.ts
@@ -2,8 +2,6 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 import { History } from 'history';
 // eslint-disable-next-line import/no-cycle
-import counterReducer from './features/counter/counterSlice';
-// eslint-disable-next-line import/no-cycle
 import observerReducer from './features/observer/observerSlice';
 // eslint-disable-next-line import/no-cycle
 import settingsReducer from './features/settings/settingsSlice';
@@ -11,7 +9,6 @@ import settingsReducer from './features/settings/settingsSlice';
 export default function createRootReducer(history: History) {
   return combineReducers({
     router: connectRouter(history),
-    counter: counterReducer,
     observer: observerReducer,
     settings: settingsReducer,
   });

--- a/app/utils/typeKeeper.ts
+++ b/app/utils/typeKeeper.ts
@@ -23,9 +23,22 @@ export interface SettingsType {
 
 export interface SettingPreferenceType {
   launchAtBoot: boolean;
-  alertInfo: {
-    enabled: boolean;
+  isPomodoroEnabled: boolean;
+}
+
+export interface PomodoroTrackerType {
+  work: {
+    isActive: boolean;
+    iteration: number;
     limit: number;
+    totalTime: number;
+  };
+  break: {
+    isActive: boolean;
+    iteration: number;
+    limit: number;
+    longLimit: number;
+    totalTime: number;
   };
 }
 
@@ -33,6 +46,7 @@ export interface DailyProcessSessionType {
   [dateKey: string]: {
     processes: Array<ProcessType>;
     screenTime: number;
+    pomodoroTracker: PomodoroTrackerType;
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,10 @@
     "directories": {
       "buildResources": "resources",
       "output": "release"
-    }
+    },
+    "extraResources": [
+      "./resources/"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes
 - The issue with the icon resolved. Had to add the `resources` folder as an extra-resource in the build config b3f06d88c3e9e9b370bd0a2fa6d74ab89a7303dd

### Additions
 - Application will be placed into the system tray when tried to exit
 - At launch application will be placed into the system tray. That will give more background process alike feeling
 - Pomodoro technique will be practiced in the application upon activation on the settings tab
   - For now, default 25m/5m iterations will be practiced. In every 4th work cycle, the break will be 25 min