### PR TITLE
feat: dialog prompt implemented to get user permissions

### DIFF
--- a/app/components/ConfirmationDialog.css
+++ b/app/components/ConfirmationDialog.css
@@ -1,0 +1,50 @@
+.confirmationDialogWrapper {
+  position: absolute;
+  width: 88vw;
+  height: 6.5em;
+  background-color: gainsboro;
+  left: 0;
+  right: 0;
+  top: 3.5em; /* 3.5em on open | -2.5em closed */
+  margin: auto;
+  transition: all 0.5s ease;
+  border-radius: 0.3em;
+  color: #242c39;
+}
+
+.contentWrapper {
+  margin: 1.2em;
+}
+
+.titleSpan {
+  display: block;
+  font-weight: 600;
+}
+
+.messageSpan {
+  display: block;
+}
+
+.actionButtonWrapper {
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 40%;
+  float: right;
+  margin-top: 0.7em;
+}
+
+.actionButton {
+  padding: 0.2em;
+  width: 4em;
+  background-color: #fff;
+  text-align: center;
+  border-radius: 0.2em;
+  cursor: pointer;
+}
+
+.highlightActionButton {
+  background-color: #2e77d0;
+  color: #fff;
+}

--- a/app/components/ConfirmationDialog.tsx
+++ b/app/components/ConfirmationDialog.tsx
@@ -1,0 +1,85 @@
+import React, { useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
+import {
+  dialogData,
+  getUserResponseToDialog,
+} from '../features/dialog/dialogSlice';
+
+import CSS from './ConfirmationDialog.css';
+
+export default function ConfirmationDialog() {
+  const { actionType, isDialogOpen, message, title } = useSelector(dialogData);
+  const dispatch = useDispatch();
+  const handleDialogActionButtonClick = useCallback(
+    (target: 'cancel' | 'ok') => () => {
+      switch (target) {
+        case 'cancel':
+          dispatch(getUserResponseToDialog(false));
+          break;
+
+        case 'ok':
+          dispatch(getUserResponseToDialog(true));
+          break;
+
+        default:
+          break;
+      }
+    },
+    [dispatch]
+  );
+
+  const handleDialogActionButtonViaKey = useCallback(
+    (target: 'cancel' | 'ok') => (e: React.KeyboardEvent<HTMLElement>) => {
+      if (e.keyCode !== 32) {
+        return;
+      }
+      switch (target) {
+        case 'cancel':
+          dispatch(getUserResponseToDialog(false));
+          break;
+
+        case 'ok':
+          dispatch(getUserResponseToDialog(true));
+          break;
+        default:
+          break;
+      }
+    },
+    [dispatch]
+  );
+
+  return (
+    <div
+      className={CSS.confirmationDialogWrapper}
+      style={isDialogOpen ? { top: '3.5em' } : { top: '-2.5em' }}
+    >
+      <div className={CSS.contentWrapper}>
+        <span className={CSS.titleSpan}>{title}</span>
+        <span className={CSS.messageSpan}>{message}</span>
+        <div className={CSS.actionButtonWrapper}>
+          {actionType === 'question' && (
+            <div
+              className={CSS.actionButton}
+              onClick={handleDialogActionButtonClick('cancel')}
+              onKeyDown={handleDialogActionButtonViaKey('cancel')}
+              role="button"
+              tabIndex={0}
+            >
+              Cancel
+            </div>
+          )}
+          <div
+            className={`${CSS.actionButton} ${CSS.highlightActionButton}`}
+            onClick={handleDialogActionButtonClick('ok')}
+            onKeyDown={handleDialogActionButtonViaKey('ok')}
+            role="button"
+            tabIndex={0}
+          >
+            OK
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Footer.css
+++ b/app/components/Footer.css
@@ -1,9 +1,8 @@
 .footerWrapper {
-  height: 3em;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: 0.5em;
+  padding-top: 0.3em;
   border-top: 2px solid #3c3c3c;
 }
 
@@ -12,6 +11,8 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  width: 7em;
+  height: 3em;
 }
 
 .pomodoroCountdown {
@@ -34,4 +35,34 @@
   flex-direction: column;
   align-items: center;
   font-size: 15px;
+}
+
+.pomodoroActionsWrapper {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 7em;
+  height: 3em;
+  background-color: #232c39;
+  opacity: 0;
+  visibility: hidden;
+  transition: all ease 0.5s;
+}
+
+.pomodoroActionItem {
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.pomodoroActionItem:hover {
+  opacity: 0.5;
+}
+
+.footerMainColumn:hover .pomodoroActionsWrapper {
+  opacity: 1;
+  visibility: visible;
 }

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,11 +1,55 @@
-import React from 'react';
-import { useSelector } from 'react-redux';
-import { getCurrentIteration } from '../features/observer/observerSlice';
+import React, { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { BiReset } from 'react-icons/bi';
+
+import {
+  getCurrentIteration,
+  resetPomodoroCounter,
+} from '../features/observer/observerSlice';
+import {
+  showDialog,
+  dialogConfirmedOrRejected,
+  resetDialogResponse,
+} from '../features/dialog/dialogSlice';
+
 import CSS from './Footer.css';
 
 export default function Footer(): JSX.Element {
+  const dispatch = useDispatch();
+
   const currentPomodoroIteration = useSelector(getCurrentIteration);
+  const userResponseToDialog = useSelector(dialogConfirmedOrRejected);
+
+  useEffect(() => {
+    if (userResponseToDialog) {
+      // reset the current pomodoro counter
+      dispatch(resetPomodoroCounter());
+      dispatch(resetDialogResponse());
+    }
+  }, [userResponseToDialog, dispatch]);
+
+  const handlePomodoroCounterResetClick = useCallback(() => {
+    dispatch(
+      showDialog({
+        actionType: 'question',
+        message: 'Are you sure you want to reset your break-time?',
+        title: 'Reset break-time',
+      })
+    );
+  }, [dispatch]);
+
+  const handlePomodoroCounterResetViaKey = useCallback(() => {
+    dispatch(
+      showDialog({
+        actionType: 'question',
+        message: 'Are you sure you want to reset your break-time?',
+        title: 'Reset break-time',
+      })
+    );
+  }, [dispatch]);
+
   const isWorkIteration = currentPomodoroIteration.type === 'work';
+
   return (
     <div className={CSS.footerWrapper}>
       <div className={CSS.workInfoColumn}>
@@ -26,6 +70,18 @@ export default function Footer(): JSX.Element {
             .toISOString()
             .substr(14, 5)}
         </span>
+        <div className={CSS.pomodoroActionsWrapper}>
+          <div
+            className={CSS.pomodoroActionItem}
+            onClick={handlePomodoroCounterResetClick}
+            onKeyDown={handlePomodoroCounterResetViaKey}
+            role="button"
+            tabIndex={0}
+          >
+            <BiReset size="1.8em" />
+            Reset
+          </div>
+        </div>
       </div>
       <div className={CSS.breakInfoColumn}>
         Break

--- a/app/components/Home.css
+++ b/app/components/Home.css
@@ -1,3 +1,4 @@
 .container {
+  position: relative;
   overflow: hidden;
 }

--- a/app/components/Home.tsx
+++ b/app/components/Home.tsx
@@ -7,6 +7,7 @@ import { ProcessType } from '../utils/typeKeeper';
 // import routes from '../constants/routes.json';
 import ProcessList from './ProcessList';
 import SummaryHeader, { StartObserver, StopObserver } from './SummaryHeader';
+import ConfirmationDialog from './ConfirmationDialog';
 import SettingsDrawer from './SettingsDrawer';
 import Footer from './Footer';
 import CSS from './Home.css';
@@ -35,6 +36,8 @@ export default function Home(): JSX.Element {
 
   const renderProcessList = useMemo(() => <ProcessList />, []);
 
+  const renderConfirmationDialog = useMemo(() => <ConfirmationDialog />, []);
+
   const renderSummaryHeader = useMemo(() => <SummaryHeader />, []);
 
   const renderSettingsDrawer = useMemo(() => <SettingsDrawer />, []);
@@ -43,6 +46,7 @@ export default function Home(): JSX.Element {
 
   return (
     <div className={CSS.container}>
+      {renderConfirmationDialog}
       {renderSummaryHeader}
       {/* <Link to={routes.COUNTER}>to Counter</Link> */}
       {renderSettingsDrawer}

--- a/app/components/SummaryHeader.css
+++ b/app/components/SummaryHeader.css
@@ -1,11 +1,12 @@
 .headerWrapper {
-  width: 100vw;
+  position: relative;
   height: 3.5em;
   display: flex;
   justify-content: center;
   align-items: center;
   padding-bottom: 0.5em;
   border-bottom: 2px solid #3c3c3c;
+  background: #232c39;
 }
 
 .sessionInformationSection {

--- a/app/features/dialog/dialogSlice.ts
+++ b/app/features/dialog/dialogSlice.ts
@@ -1,0 +1,48 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+// eslint-disable-next-line import/no-cycle
+import { RootState } from '../../store';
+import { ConfirmationDialogTypes } from '../../utils/typeKeeper';
+
+const prepareInitialState = (): ConfirmationDialogTypes => {
+  return {
+    isDialogOpen: false,
+    title: '',
+    message: '',
+    actionType: 'info',
+    dialogConfirmedOrRejected: undefined,
+  };
+};
+
+const DialogSlice = createSlice({
+  name: 'dialog',
+  initialState: prepareInitialState(),
+  reducers: {
+    showDialog: (state, action: PayloadAction<ConfirmationDialogTypes>) => {
+      state.isDialogOpen = true;
+      state.actionType = action.payload.actionType;
+      state.message = action.payload.message;
+      state.title = action.payload.title;
+    },
+    getUserResponseToDialog: (state, action: PayloadAction<boolean>) => {
+      state.dialogConfirmedOrRejected = action.payload;
+      state.isDialogOpen = false;
+    },
+    resetDialogResponse: (state) => {
+      state.dialogConfirmedOrRejected = undefined;
+    },
+  },
+});
+
+export const {
+  showDialog,
+  getUserResponseToDialog,
+  resetDialogResponse,
+} = DialogSlice.actions;
+
+export default DialogSlice.reducer;
+
+export const dialogData = (state: RootState) => state.dialogBox;
+
+export const dialogConfirmedOrRejected = (state: RootState) =>
+  state.dialogBox.dialogConfirmedOrRejected;

--- a/app/features/observer/observerSlice.ts
+++ b/app/features/observer/observerSlice.ts
@@ -171,6 +171,15 @@ const observerSlice = createSlice({
       }
       UpdatePomodoroTotalBreakTime(date, isIteration);
     },
+    resetPomodoroCounter: (state) => {
+      if (state.pomodoroTracker.break.isActive) {
+        state.pomodoroTracker.break.totalTime = 0;
+        UpdatePomodoroTotalBreakTime(date, false, true);
+      } else {
+        state.pomodoroTracker.work.totalTime = 0;
+        UpdatePomodoroTotalWorkTime(date, false, true);
+      }
+    },
   },
 });
 
@@ -182,6 +191,7 @@ export const {
   incrementPomodoroWorkTimeByOneSecond,
   setPomodoroBreakLimit,
   setPomodoroWorkLimit,
+  resetPomodoroCounter,
 } = observerSlice.actions;
 
 export const observeProcess = (incomingProcess: ProcessType): AppThunk => {

--- a/app/rootReducer.ts
+++ b/app/rootReducer.ts
@@ -2,6 +2,8 @@ import { combineReducers } from 'redux';
 import { connectRouter } from 'connected-react-router';
 import { History } from 'history';
 // eslint-disable-next-line import/no-cycle
+import dialogReducer from './features/dialog/dialogSlice';
+// eslint-disable-next-line import/no-cycle
 import observerReducer from './features/observer/observerSlice';
 // eslint-disable-next-line import/no-cycle
 import settingsReducer from './features/settings/settingsSlice';
@@ -9,6 +11,7 @@ import settingsReducer from './features/settings/settingsSlice';
 export default function createRootReducer(history: History) {
   return combineReducers({
     router: connectRouter(history),
+    dialogBox: dialogReducer,
     observer: observerReducer,
     settings: settingsReducer,
   });

--- a/app/utils/electronStore.ts
+++ b/app/utils/electronStore.ts
@@ -104,7 +104,8 @@ export const UpdatePomodoroBreakLimit = (
 
 export const UpdatePomodoroTotalWorkTime = (
   key: string,
-  isIteration: boolean
+  isIteration: boolean,
+  reset?: boolean
 ) => {
   const oldSession = getStoreData('dailySessions') as DailyProcessSessionType;
   oldSession[key].pomodoroTracker.work.totalTime += 1;
@@ -114,12 +115,16 @@ export const UpdatePomodoroTotalWorkTime = (
     oldSession[key].pomodoroTracker.break.isActive = true;
     oldSession[key].pomodoroTracker.work.totalTime = 0;
   }
+  if (reset) {
+    oldSession[key].pomodoroTracker.work.totalTime = 0;
+  }
   config.store?.set(`dailySessions.${key}`, oldSession[key]);
 };
 
 export const UpdatePomodoroTotalBreakTime = (
   key: string,
-  isIteration: boolean
+  isIteration: boolean,
+  reset?: boolean
 ) => {
   const oldSession = getStoreData('dailySessions') as DailyProcessSessionType;
   oldSession[key].pomodoroTracker.break.totalTime += 1;
@@ -127,6 +132,9 @@ export const UpdatePomodoroTotalBreakTime = (
     oldSession[key].pomodoroTracker.break.iteration += 1;
     oldSession[key].pomodoroTracker.work.isActive = true;
     oldSession[key].pomodoroTracker.break.isActive = false;
+    oldSession[key].pomodoroTracker.break.totalTime = 0;
+  }
+  if (reset) {
     oldSession[key].pomodoroTracker.break.totalTime = 0;
   }
   config.store?.set(`dailySessions.${key}`, oldSession[key]);

--- a/app/utils/typeKeeper.ts
+++ b/app/utils/typeKeeper.ts
@@ -54,3 +54,11 @@ export interface StoreType {
   dailySessions: DailyProcessSessionType;
   settings: SettingsType;
 }
+
+export interface ConfirmationDialogTypes {
+  isDialogOpen?: boolean;
+  title: string;
+  message: string;
+  actionType: 'info' | 'question' | 'warning';
+  dialogConfirmedOrRejected?: boolean | undefined;
+}


### PR DESCRIPTION
### Changes
 - 

### Additions
 - `confirmationDialog` component implemented to retrieve user input
 - Pomodoro counter can be reset by hovering on the counter, the reset button will appear upon doing so