### PR TITLE
fix: daily session creation will no longer cause empty screen

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -20,6 +20,8 @@ export default function Footer(): JSX.Element {
   const currentPomodoroIteration = useSelector(getCurrentIteration);
   const userResponseToDialog = useSelector(dialogConfirmedOrRejected);
 
+  const isWorkIteration = currentPomodoroIteration.type === 'work';
+
   useEffect(() => {
     if (userResponseToDialog) {
       // reset the current pomodoro counter
@@ -32,11 +34,11 @@ export default function Footer(): JSX.Element {
     dispatch(
       showDialog({
         actionType: 'question',
-        message: 'Are you sure you want to reset your break-time?',
-        title: 'Reset break-time',
+        message: `Are you sure you want to reset your ${currentPomodoroIteration.type}-time?`,
+        title: `Reset ${currentPomodoroIteration.type}-time`,
       })
     );
-  }, [dispatch]);
+  }, [dispatch, currentPomodoroIteration.type]);
 
   const handlePomodoroCounterResetViaKey = useCallback(() => {
     dispatch(
@@ -47,8 +49,6 @@ export default function Footer(): JSX.Element {
       })
     );
   }, [dispatch]);
-
-  const isWorkIteration = currentPomodoroIteration.type === 'work';
 
   return (
     <div className={CSS.footerWrapper}>

--- a/app/features/observer/observerSlice.ts
+++ b/app/features/observer/observerSlice.ts
@@ -55,8 +55,26 @@ const prepareInitialState = () => {
     });
   }
   const todaysSession = sessions && sessions[date];
-  if (todaysSession) {
-    return { ...todaysSession };
+  if (!todaysSession) {
+    Storage.set(`dailySessions.${date}`, {
+      pomodoroTracker: {
+        work: {
+          isActive: true,
+          iteration: 0,
+          limit: 1500,
+          totalTime: 0,
+        },
+        break: {
+          isActive: false,
+          iteration: 0,
+          limit: 300,
+          longLimit: 1500,
+          totalTime: 0,
+        },
+      },
+      screenTime: 0,
+      processes: [],
+    });
   }
   return Storage.get('dailySessions')[date];
 };

--- a/app/features/observer/observerSlice.ts
+++ b/app/features/observer/observerSlice.ts
@@ -26,6 +26,14 @@ const prepareInitialState = () => {
   const sessions = Storage.get('dailySessions');
   if (!sessions) {
     // Very first run of the app, create the config.json file with empty object
+    Storage.set('settings', <SettingsType>{
+      preferences: {
+        launchAtBoot: true,
+        isPomodoroEnabled: false,
+      },
+    });
+  }
+  if (!sessions[date]) {
     Storage.set('dailySessions', <DailyProcessSessionType>{
       [date]: {
         pomodoroTracker: {
@@ -45,12 +53,6 @@ const prepareInitialState = () => {
         },
         screenTime: 0,
         processes: [],
-      },
-    });
-    Storage.set('settings', <SettingsType>{
-      preferences: {
-        launchAtBoot: true,
-        isPomodoroEnabled: false,
       },
     });
   }


### PR DESCRIPTION
### Changes
 - `observerSlice` initial state generation won't cause trouble on new sessions
